### PR TITLE
Fix distribution variable name

### DIFF
--- a/chapters/02-bayesRule.md
+++ b/chapters/02-bayesRule.md
@@ -94,7 +94,7 @@ var posteriorDistibution = Infer({
   model: model, method: "rejection", samples: 1000
 })
 
-viz(posteriorDist)
+viz(posteriorDistibution)
 ~~~~
 
 The output of `Infer()` is a distribution object, in the same way as the built-in distributions like `Binomial()`.


### PR DESCRIPTION
Hi, 

fixed a variable name in Chapter 2. Makes the example run without an error. 

Cheers, 
Markus